### PR TITLE
Changes for scenarios.json to support default values set in the launcher

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -140,9 +140,12 @@ Resources:
             - Effect: Allow
               Action: s3:Put*
               Resource:
-                - Fn::GetAtt:
-                  - S3Bucket
-                  - Arn
+              - Fn::Join:
+                - /
+                - - Fn::GetAtt:
+                    - S3Bucket
+                    - Arn
+                  - '*'
             - Effect: Allow
               Action:
                 - logs:CreateLogGroup

--- a/template.yml
+++ b/template.yml
@@ -418,3 +418,6 @@ Outputs:
   SendSimSummaryFunction:
     Description: "SendSimSummary Function ARN"
     Value: !GetAtt SendSimSummaryFunction.Arn
+  BucketName:
+    Description: "S3 bucket for testing application"
+    Value: !Ref S3Bucket

--- a/template.yml
+++ b/template.yml
@@ -236,6 +236,7 @@ Resources:
                 - codepipeline:PutApprovalResult
                 - s3:ListAllMyBuckets
                 - s3:CreateJob
+                - iam:CreateServiceLinkedRole
               Resource: '*'
             - Effect: Allow
               Action: 

--- a/template.yml
+++ b/template.yml
@@ -207,6 +207,7 @@ Resources:
                 - codepipeline:PollForJobs
                 - s3:GetAccessPoint
                 - s3:GetObject
+                - xray:PutTraceSegments
                 - cloudwatch:PutMetricData
                 - robomaker:DescribeSimulationJobBatch
                 - robomaker:BatchDescribeSimulationJob
@@ -224,6 +225,7 @@ Resources:
                 - s3:ListJobs
                 - logs:CreateLogGroup
                 - logs:PutLogEvents
+                - logs:DescribeLogGroups
                 - robomaker:StartSimulationJobBatch
                 - robomaker:DescribeSimulationJob
                 - robomaker:ListSimulationJobBatches


### PR DESCRIPTION
*Issue #, if available:*
It's little difficult to apply the default parameters which are set by simulation launcher to the scenarios.json. 
 
*Description of changes:*
outputLocation, iamRole, securityGroups, subnets are from launcher if they are not set in scenarios.json file. 
Print S3 bucket name created by CloudFormation for easy to find out where bundle need to be placed for the workload. 